### PR TITLE
Change how we handle the preseed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ Which Ubuntu image to fetch and customise, and where to place the resulting imag
     buildiso_output: custom.iso
     buildiso_image: disco-desktop-amd64.iso
 
-Select which `/preseed/<filename>.seed` to modify by setting `buildiso_preseed`. You could change this to a different one, but you still need to alter your `buildiso_menu` to make use of it.
-To include additional your own content for the preseed file, use the variable `buildiso_preseed_content`. The content of `preseed/ubuntu.seed` will always be included first in the file and
-you need to specify variables again to override them.
+Select which `/preseed/<filename>.seed` to modify by setting `buildiso_preseed_name`. You could change this to a different one, but you still need to alter your `buildiso_menu` to make use of it.
+To include additional your own content for the preseed file, use the variable `buildiso_preseed_content`. The content of the file `/preseed/ubuntu.seed` is default.
 
-    buildiso_preseed: ubuntu
+    buildiso_preseed_name: ubuntu
     buildiso_preseed_content: None
 
 The boot menu of the image can be set to alternative options. There is no timeout in making the choice, and the default entry will be the default selection.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,13 +81,13 @@
 - name: Ensure image configuration
   template:
     src: "{{ item + '.j2' }}"
-    dest: "{{ buildiso_writable + '/' + item | regex_replace('ubuntu', buildiso_preseed | default('ubuntu')) }}"
+    dest: "{{ buildiso_writable + '/' + item | regex_replace('ubuntu', buildiso_preseed_name | default('ubuntu')) }}"
   loop:
     - boot/grub/grub.cfg
     - isolinux/txt.cfg
     - preseed/ubuntu.seed
   loop_control:
-    label: "{{ '/' + item | regex_replace('ubuntu', buildiso_preseed | default('ubuntu')) }}"
+    label: "{{ '/' + item | regex_replace('ubuntu', buildiso_preseed_name | default('ubuntu')) }}"
   register: buildiso_template
 
 - name: Create file target directory

--- a/templates/preseed/ubuntu.seed.j2
+++ b/templates/preseed/ubuntu.seed.j2
@@ -1,2 +1,1 @@
-{{ buildiso_readfiles.results | to_json | from_json | json_query('[?item==`/preseed/ubuntu.seed`].content') | b64decode }}
-{{ buildiso_preseed_content if buildiso_preseed_content is defined else None }}
+{{ buildiso_preseed_content | default(buildiso_readfiles.results | to_json | from_json | json_query('[?item==`/preseed/ubuntu.seed`].content') | b64decode, true) }}


### PR DESCRIPTION
The default preseed file content is now `/preseed/
ubuntu.seed`. Renamed variable buildiso_preseed to
buildiso_preseed_name.