### PR TITLE
Change download ISO workaround to default variables instead since we …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 buildiso_input: http://cdimage.ubuntu.com/daily-live/current/eoan-desktop-amd64.iso
-buildiso_output: custom.iso
+buildiso_output: ./custom.iso
 
 buildiso_menu:
   - name: Try Ubuntu without installing

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Download ISO image
   get_url:
     url: "{{ buildiso_input }}"
-    dest: "{{ './' + buildiso_image }}"
+    dest: "{{ buildiso_image }}"
     checksum: "{{ 'sha256:' + buildiso_download_checksum.content | regex_replace('\n', '') | \
                   regex_replace('^.*([a-z0-9]{64})\\ \\*' + buildiso_image | \
                   basename + '.*$', '\\1') }}"


### PR DESCRIPTION
…managed to break setting buildiso_output to an absolute path.